### PR TITLE
Added sysinfoapi to winapi features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ name = "jector"
 doc = false
 
 [dependencies]
-winapi = { version = "0.3.9", features = ["winnt", "winuser", "processthreadsapi", "handleapi", "memoryapi", "winbase", "errhandlingapi", "synchapi", "tlhelp32", "psapi", "wow64apiset", "impl-default"] }
+winapi = { version = "0.3.9", features = ["winnt", "winuser", "processthreadsapi", "handleapi", "memoryapi", "winbase", "errhandlingapi", "synchapi", "tlhelp32", "psapi", "wow64apiset", "impl-default", "sysinfoapi"] }
 pelite = "0.9.0"
 bitflags = "1.2.1"
 field-offset = "0.3.2"


### PR DESCRIPTION
It's used but not added as a feature which causes an error when building (src\winapiwrapper\module.rs:13:17)